### PR TITLE
Remove FREE THE WORK

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,6 @@ Please read the [Code of Conduct](CODE_OF_CONDUCT.md) and [guidelines](CONTRIBUT
 
 - **[First Look Media](https://firstlook.media/)**  | _Public service_ | New York, NY | **Remote friendly**? ✅ | [Current openings](https://boards.greenhouse.io/firstlookmedia) | **Nonprofit**? ❌ | Supporting independent voices, from fearless investigative journalism and documentary filmmaking to smart, provocative entertainment
 
-- **[FREE THE WORK](https://freethework.com/)**  | _Human rights_ | Los Angeles, CA | **Remote friendly**? ✅ | [Current openings](https://freethework.com/jobs) | **Nonprofit**? ✅ | Identifying systemic inequalities in film, television, advertising, and media, and finding actionable solutions to expand access for underrepresented creators
-
 - **[GoodRx](https://www.goodrx.com/)**  | _Health_ | Santa Monica, CA | **Remote friendly**? ✅ | [Current openings](https://www.goodrx.com/jobs/openings/) | **Nonprofit**? ❌ | Help people get the healthcare they need at a price they can afford
 
 - **[Guild Education](https://www.guildeducation.com/)**  | _Education_ | Denver, CO | **Remote friendly**? ✅ | [Current openings](https://www.guildeducation.com/about-us/careers/) | **Nonprofit**? ❌ | Unlock opportunity for America’s workforce through education and upskilling with a double bottom line business model that does well by doing good


### PR DESCRIPTION
FREE THE WORK is no longer in business.

From their website,

> To Our Beloved Creators and Partners,
> As we transition our database and redefine our mission, we celebrate the achievements we’ve made together.
> 
> FREE THE WORK has closed its current operations.